### PR TITLE
fix DCS_SLOW_TO_CHG

### DIFF
--- a/src/isp_bldc_motor.spin2
+++ b/src/isp_bldc_motor.spin2
@@ -903,8 +903,8 @@ PRI offsetsForMotor(eMotorType) : fwdDegrees, revDegrees | ofsDegr
         }
 
         ' Chips values (orig driver)
-        ' CHIP ORIG: offset_fwd	long	280 frac 360			'280 frac 360 (Doug's motor) 20
-        ' CHIP ORIG: offset_rev	long	230 frac 360			'230 frac 360 (Doug's motor) 340
+        ' CHIP ORIG: offset_fwd long    280 frac 360                    '280 frac 360 (Doug's motor) 20
+        ' CHIP ORIG: offset_rev long    230 frac 360                    '230 frac 360 (Doug's motor) 340
 
         ' my values from characterization at 18v5:
         ofsDegr := 43
@@ -2047,8 +2047,7 @@ driver          mov     drv_state_, #DCS_STOPPED        ' motor is currently sto
                 or      drv_incr, drv_incr          wz  ' Q: stopped?
     if_z        jmp     #.endS2CAtZero                  ' yes, go start rampUp
                 ' calculate how far we are from desired
-                mov     final_ramp, tgt_incr              ' compute our delta from curr to target
-                subs    final_ramp, drv_incr
+                mov     final_ramp, drv_incr              ' compute our delta from curr to target
                 ' now are we moving FWD or REV?
                 testb   drv_incr, #31               wc  ' YES, moving FWD or REV? (bCY=REV)
     if_c        jmp     #.haveS2CRev                    ' REV, go handle reverse


### PR DESCRIPTION
depending on initial tgt_incr doesn't always change direction. Since we are slowing to 0, final ramp needs computing against 0, not the tgt_incr so final ramp is never used